### PR TITLE
Fix undefined behavior

### DIFF
--- a/wyhash.h
+++ b/wyhash.h
@@ -30,7 +30,7 @@ inline	unsigned long long	wyhashread16(const	void	*const	ptr){	return	*(unsigned
 inline	unsigned long long	wyhashread08(const	void	*const	ptr){	return	*(unsigned char*)(ptr);	}
 inline	unsigned long long	wyhash(const void* key,	unsigned long long	len, unsigned long long	seed){
 	const	unsigned char	*ptr=(const	unsigned char*)key,	*const	end=ptr+len;
-	for(;	UNLIKELY(ptr+32<end);	ptr+=32)	seed=wyhashmix(seed^wyhashp1,wyhashread64(ptr))^wyhashmix(seed^wyhashp2,wyhashread64(ptr+8))^wyhashmix(seed^wyhashp3,wyhashread64(ptr+16))^wyhashmix(seed^wyhashp4,wyhashread64(ptr+24));
+	for(;	UNLIKELY(end-ptr<32);	ptr+=32)	seed=wyhashmix(seed^wyhashp1,wyhashread64(ptr))^wyhashmix(seed^wyhashp2,wyhashread64(ptr+8))^wyhashmix(seed^wyhashp3,wyhashread64(ptr+16))^wyhashmix(seed^wyhashp4,wyhashread64(ptr+24));
 	switch(len&31){
 	case	0:	seed=wyhashmix(seed^wyhashp1,wyhashread64(ptr))^wyhashmix(seed^wyhashp2,wyhashread64(ptr+8))^wyhashmix(seed^wyhashp3,wyhashread64(ptr+16))^wyhashmix(seed^wyhashp4,wyhashread64(ptr+24));	break;
 	case	1:	seed=wyhashmix(seed^wyhashp1,wyhashread08(ptr));	break;	


### PR DESCRIPTION
The C standard only permits pointers to be compared if both pointers
point to the same memory object. If ptr+32>end, then technically, ptr+32
may be an invalid pointer and it is undefined behavior to compare it to
end.

See: https://stackoverflow.com/a/17584465/82294