### PR TITLE
Fix SMHasher avalanche failure on 136 bits.

### DIFF
--- a/wyhash.h
+++ b/wyhash.h
@@ -1,7 +1,7 @@
 /*Author: Wang Yi <godspeed_china@yeah.net>*/
 #ifndef wyhash_included
 #define wyhash_included
-#define wyhash_version	20190319
+#define wyhash_version	20190320
 const	unsigned long long	_wyp0=0x60bee2bee120fc15ull;
 const	unsigned long long	_wyp1=0xa3b195354a39b70dull;
 const	unsigned long long	_wyp2=0x1b03738712fad5c9ull;
@@ -11,6 +11,9 @@ const	unsigned long long	_wyp5=0xc104aa67c96b7d55ull;
 static	inline	unsigned long long	_wymum(unsigned long long	A,	unsigned long long	B){
 #ifdef __SIZEOF_INT128__
 	__uint128_t	r=A;	r*=B;	return	(r>>64)^r;
+#elif defined(_MSC_VER)
+	A = _umul128(A, B, &B);
+	return A ^ B;
 #else
 	unsigned long long	ha=A>>32,	hb=B>>32,	la=(unsigned int)A,	lb=(unsigned int)B,	hi, lo;
 	unsigned long long	rh=ha*hb,	rm0=ha*lb,	rm1=hb*la,	rl=la*lb,	t=rl+(rm0<<32),	c=t<rl;
@@ -44,21 +47,21 @@ static	inline	unsigned long long	wyhash(const void* key,	unsigned long long	len,
 	case	14:	seed=_wymum(__wyr64(p)^seed,((_wyr32(p+8)<<16)|_wyr16(p+8+4))^_wyp2);	break;
 	case	15:	seed=_wymum(__wyr64(p)^seed,((_wyr32(p+8)<<24)|(_wyr16(p+8+4)<<8)|_wyr08(p+8+6))^_wyp2);	break;
 	case	16:	seed=_wymum(__wyr64(p)^seed,__wyr64(p+8)^_wyp2);	break;
-	case	17:	seed=_wymum(__wyr64(p)^seed,__wyr64(p+8)^_wyp2)+_wymum(seed,_wyr08(p+16)^_wyp3);	break;
-	case	18:	seed=_wymum(__wyr64(p)^seed,__wyr64(p+8)^_wyp2)+_wymum(seed,_wyr16(p+16)^_wyp3);	break;
-	case	19:	seed=_wymum(__wyr64(p)^seed,__wyr64(p+8)^_wyp2)+_wymum(seed,((_wyr16(p+16)<<8)|_wyr08(p+16+2))^_wyp3);	break;
-	case	20:	seed=_wymum(__wyr64(p)^seed,__wyr64(p+8)^_wyp2)+_wymum(seed,_wyr32(p+16)^_wyp3);	break;
-	case	21:	seed=_wymum(__wyr64(p)^seed,__wyr64(p+8)^_wyp2)+_wymum(seed,((_wyr32(p+16)<<8)|_wyr08(p+16+4))^_wyp3);	break;
-	case	22:	seed=_wymum(__wyr64(p)^seed,__wyr64(p+8)^_wyp2)+_wymum(seed,((_wyr32(p+16)<<16)|_wyr16(p+16+4))^_wyp3);	break;
-	case	23:	seed=_wymum(__wyr64(p)^seed,__wyr64(p+8)^_wyp2)+_wymum(seed,((_wyr32(p+16)<<24)|(_wyr16(p+16+4)<<8)|_wyr08(p+16+6))^_wyp3);	break;
-	case	24:	seed=_wymum(__wyr64(p)^seed,__wyr64(p+8)^_wyp2)+_wymum(seed,__wyr64(p+16)^_wyp3);	break;
-	case	25:	seed=_wymum(__wyr64(p)^seed,__wyr64(p+8)^_wyp2)+_wymum(__wyr64(p+16)^seed,_wyr08(p+24)^_wyp4);	break;
-	case	26:	seed=_wymum(__wyr64(p)^seed,__wyr64(p+8)^_wyp2)+_wymum(__wyr64(p+16)^seed,_wyr16(p+24)^_wyp4);	break;
-	case	27:	seed=_wymum(__wyr64(p)^seed,__wyr64(p+8)^_wyp2)+_wymum(__wyr64(p+16)^seed,((_wyr16(p+24)<<8)|_wyr08(p+24+2))^_wyp4);	break;
-	case	28:	seed=_wymum(__wyr64(p)^seed,__wyr64(p+8)^_wyp2)+_wymum(__wyr64(p+16)^seed,_wyr32(p+24)^_wyp4);	break;
-	case	29:	seed=_wymum(__wyr64(p)^seed,__wyr64(p+8)^_wyp2)+_wymum(__wyr64(p+16)^seed,((_wyr32(p+24)<<8)|_wyr08(p+24+4))^_wyp4);	break;
-	case	30:	seed=_wymum(__wyr64(p)^seed,__wyr64(p+8)^_wyp2)+_wymum(__wyr64(p+16)^seed,((_wyr32(p+24)<<16)|_wyr16(p+24+4))^_wyp4);	break;
-	case	31:	seed=_wymum(__wyr64(p)^seed,__wyr64(p+8)^_wyp2)+_wymum(__wyr64(p+16)^seed,((_wyr32(p+24)<<24)|(_wyr16(p+24+4)<<8)|_wyr08(p+24+6))^_wyp4);	break;
+	case	17:	seed=_wymum(__wyr64(p)^seed,__wyr64(p+8)^_wyp2)^_wymum(seed,_wyr08(p+16)^_wyp3);	break;
+	case	18:	seed=_wymum(__wyr64(p)^seed,__wyr64(p+8)^_wyp2)^_wymum(seed,_wyr16(p+16)^_wyp3);	break;
+	case	19:	seed=_wymum(__wyr64(p)^seed,__wyr64(p+8)^_wyp2)^_wymum(seed,((_wyr16(p+16)<<8)|_wyr08(p+16+2))^_wyp3);	break;
+	case	20:	seed=_wymum(__wyr64(p)^seed,__wyr64(p+8)^_wyp2)^_wymum(seed,_wyr32(p+16)^_wyp3);	break;
+	case	21:	seed=_wymum(__wyr64(p)^seed,__wyr64(p+8)^_wyp2)^_wymum(seed,((_wyr32(p+16)<<8)|_wyr08(p+16+4))^_wyp3);	break;
+	case	22:	seed=_wymum(__wyr64(p)^seed,__wyr64(p+8)^_wyp2)^_wymum(seed,((_wyr32(p+16)<<16)|_wyr16(p+16+4))^_wyp3);	break;
+	case	23:	seed=_wymum(__wyr64(p)^seed,__wyr64(p+8)^_wyp2)^_wymum(seed,((_wyr32(p+16)<<24)|(_wyr16(p+16+4)<<8)|_wyr08(p+16+6))^_wyp3);	break;
+	case	24:	seed=_wymum(__wyr64(p)^seed,__wyr64(p+8)^_wyp2)^_wymum(seed,__wyr64(p+16)^_wyp3);	break;
+	case	25:	seed=_wymum(__wyr64(p)^seed,__wyr64(p+8)^_wyp2)^_wymum(__wyr64(p+16)^seed,_wyr08(p+24)^_wyp4);	break;
+	case	26:	seed=_wymum(__wyr64(p)^seed,__wyr64(p+8)^_wyp2)^_wymum(__wyr64(p+16)^seed,_wyr16(p+24)^_wyp4);	break;
+	case	27:	seed=_wymum(__wyr64(p)^seed,__wyr64(p+8)^_wyp2)^_wymum(__wyr64(p+16)^seed,((_wyr16(p+24)<<8)|_wyr08(p+24+2))^_wyp4);	break;
+	case	28:	seed=_wymum(__wyr64(p)^seed,__wyr64(p+8)^_wyp2)^_wymum(__wyr64(p+16)^seed,_wyr32(p+24)^_wyp4);	break;
+	case	29:	seed=_wymum(__wyr64(p)^seed,__wyr64(p+8)^_wyp2)^_wymum(__wyr64(p+16)^seed,((_wyr32(p+24)<<8)|_wyr08(p+24+4))^_wyp4);	break;
+	case	30:	seed=_wymum(__wyr64(p)^seed,__wyr64(p+8)^_wyp2)^_wymum(__wyr64(p+16)^seed,((_wyr32(p+24)<<16)|_wyr16(p+24+4))^_wyp4);	break;
+	case	31:	seed=_wymum(__wyr64(p)^seed,__wyr64(p+8)^_wyp2)^_wymum(__wyr64(p+16)^seed,((_wyr32(p+24)<<24)|(_wyr16(p+24+4)<<8)|_wyr08(p+24+6))^_wyp4);	break;
 	}
 	return	_wymum(seed,	len^_wyp5);
 }


### PR DESCRIPTION
This also allows wyhash to use MSVC's _umul128 when __uint128_t is not available, but we know we can use MSVC intrinsics. This allows wyhash to reach high speeds even on MSVC's hobbled toolchain.

There's also a slight change to the small-hashes case, only affecting inputs with length where `(length & 31) > 16`; I changed each case's `+` between two _wymum() calls to `^`, and this allows wyhash to pass SMHasher's avalanche test. For me, the version without this change failed at 136 bits reliably, having a high bias of 13.110000%; now all tests pass.

I also changed the version to... apparently still the wrong day. Feel free to edit whatever you want here; my code style probably doesn't match in places.