### PR TITLE
fixed compiler warning reported by gcc with flags -O3 -Wall

### DIFF
--- a/wyhash.h
+++ b/wyhash.h
@@ -66,5 +66,5 @@ static	inline	unsigned long long	wyhash(const void* key,	unsigned long long	len,
 }
 static	inline	unsigned long long	wyhash64(unsigned long long	A, unsigned long long	B){	return	_wymum(_wymum(A^_wyp0,	B^_wyp1),	_wyp2);	}
 static	inline	unsigned long long	wyrand(unsigned long long *s){	*s+=_wyp0;	return	_wymum(*s^_wyp1,*s);	}
-static	inline	double	wyrandu01(unsigned long long	*seed){	unsigned long long	r=(wyrand(seed)&0xfffffffffffffull)|0x3ff0000000000000ull;	return	*((double*)&r)-1.0;		}
+static	inline	double	wyrandu01(unsigned long long	*seed){	return (wyrand(seed) & 0x000fffffffffffffull) * 0x1p-52; }
 #endif


### PR DESCRIPTION
This pull request fixes following compiler warning which is reported by gcc when compiling wyhash.h using `gcc -O3 -Wall`:

`wyhash/wyhash.h: In function ‘double wyrandu01(long long unsigned int*)’:
wyhash/wyhash.h:69:157: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
 static inline double wyrandu01(unsigned long long *seed){ unsigned long long r=(wyrand(seed)&0xfffffffffffffull)|0x3ff0000000000000ull; return *((double*)&r)-1.0;  }`