### PR TITLE
Fix avalanche when 31 & keylen = 0

### DIFF
--- a/wyhash.h
+++ b/wyhash.h
@@ -33,6 +33,7 @@ static	inline	uint64_t	wyhash(const void* key,	uint64_t	len, uint64_t	seed){
 	const	uint8_t	*p=(const	uint8_t*)key;	uint64_t i;
 	for(i=0;	i+32<=len;	i+=32,	p+=32)	seed=_wymix0(_wyr64(p),_wyr64(p+8),seed)^_wymix1(_wyr64(p+16),_wyr64(p+24),seed);
 	switch(len&31){
+	case    0:  seed=_wymix0(_wyp1^seed,_wyp4,_wyp0+seed); break;
 	case	1:	seed=_wymix0(_wyr08(p),_wyp4,seed);	break;
 	case	2:	seed=_wymix0(_wyr16(p),_wyp4,seed);	break;
 	case	3:	seed=_wymix0((_wyr16(p)<<8)|_wyr08(p+2),_wyp4,seed);	break;


### PR DESCRIPTION
Yves Orton's much stricter version of SMHasher (with g-test instead of chi2) was failing wyhash on its avalanche test with 0-length keys. While 0-length keys are not a concern for most applications, this is meant to be a universally-applicable hash function and doing this is faster than, say, checking before calling the hash function. Additionally, if left as is, ``seed`` is much easier to derive since the function reduces to  ``_wymum(seed,    _wyp4)`` and ``_wyp4`` is known - if ``seed`` is meant to be secret as you advise, this would make it weaker. 