### PR TITLE
Improved 31 & len = 0 handling, per your requirements and now faster

### DIFF
--- a/wyhash.h
+++ b/wyhash.h
@@ -34,7 +34,7 @@ static	inline	uint64_t	wyhash(const void* key,	uint64_t	len, uint64_t	seed){
 	uint64_t mix = len;
 	for(i=0;	i+32<=len;	i+=32,	p+=32)	seed=_wymix0(_wyr64(p),_wyr64(p+8),seed)^_wymix1(_wyr64(p+16),_wyr64(p+24),seed);
 	switch(len&31){
-	case 	0:	mix= _wymum(seed^_wyp0,seed^_wyp1); break;
+	case 	0:	mix=  len ? mix: _wymum(_wyp0,seed); break;
 	case	1:	seed=_wymix0(_wyr08(p),_wyp4,seed);	break;
 	case	2:	seed=_wymix0(_wyr16(p),_wyp4,seed);	break;
 	case	3:	seed=_wymix0((_wyr16(p)<<8)|_wyr08(p+2),_wyp4,seed);	break;

--- a/wyhash.h
+++ b/wyhash.h
@@ -31,9 +31,10 @@ static	inline	uint64_t	__wyr64(const	uint8_t	*p){	return	(_wyr32(p)<<32)|_wyr32(
 //to avoid attacks, seed should be initialized as a secret
 static	inline	uint64_t	wyhash(const void* key,	uint64_t	len, uint64_t	seed){
 	const	uint8_t	*p=(const	uint8_t*)key;	uint64_t i;
+	uint64_t mix = len;
 	for(i=0;	i+32<=len;	i+=32,	p+=32)	seed=_wymix0(_wyr64(p),_wyr64(p+8),seed)^_wymix1(_wyr64(p+16),_wyr64(p+24),seed);
 	switch(len&31){
-	case    0:  seed=_wymix0(_wyp1^seed,_wyp4,_wyp0+seed); break;
+	case 	0:	mix= _wymum(seed^_wyp0,seed^_wyp1); break;
 	case	1:	seed=_wymix0(_wyr08(p),_wyp4,seed);	break;
 	case	2:	seed=_wymix0(_wyr16(p),_wyp4,seed);	break;
 	case	3:	seed=_wymix0((_wyr16(p)<<8)|_wyr08(p+2),_wyp4,seed);	break;
@@ -66,7 +67,8 @@ static	inline	uint64_t	wyhash(const void* key,	uint64_t	len, uint64_t	seed){
 	case	30:	seed=_wymix0(__wyr64(p),__wyr64(p+8),seed)^_wymix1(__wyr64(p+16),(_wyr32(p+24)<<16)|_wyr16(p+24+4),seed);	break;
 	case	31:	seed=_wymix0(__wyr64(p),__wyr64(p+8),seed)^_wymix1(__wyr64(p+16),(_wyr32(p+24)<<24)|(_wyr16(p+24+4)<<8)|_wyr08(p+24+6),seed);	break;
 	}
-	return	_wymum(seed^len,	_wyp4);
+
+	return _wymum(seed^mix, _wyp4);
 }
 static	inline	uint64_t	wyhash64(uint64_t	A, uint64_t	B){	return	_wymum(_wymum(A^_wyp0,	B^_wyp1),	_wyp2);	}
 static	inline	double	wy2u01(uint64_t	r){	const	double	_wynorm=1.0/(1ull<<52);	return	(r&0x000fffffffffffffull)*_wynorm; }


### PR DESCRIPTION
GCC branching hints have no direct effect on x86 except on a Pentium 4. Introducing them might make the compiler stick the len != 0 case elsewhere, but that's actually a loss (since we're going to hit it more often than len = 0).

The **fastest** thing to do is to not have a conditional checking for len = 0 and do the round anyway. Since you don't want that for some nebulous 'mathematical elegance' reason (which I think is mistaken - if you can get more mixing rounds for free, you ought to take them), here is a version that makes that conditional as fast as possible. It is now faster in SMHasher tests than the original on my SkylakeX test machine with march and mtune = skylake-avx512. The version without a conditional would still be faster in real-world use.