### PR TITLE
Add v lang port & alphabetize port list

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ XXH3 was not included as it fails two tests according to SMHasher.
 
 Language Ports:
 
-**V** https://github.com/vlang/v/tree/master/vlib/hash/wyhash (v4)
+**C#**  https://github.com/cocowalla/wyhash-dotnet
+
+**C++**  https://github.com/tommyettinger/waterhash
 
 **GO**  https://github.com/dgryski/go-wyhash
 
@@ -53,21 +55,19 @@ Language Ports:
 
 **GO** https://github.com/lonewolf3739/wyhash-go
 
+**Java** https://github.com/OpenHFT/Zero-Allocation-Hashing
+
+**Rust**  https://github.com/eldruin/wyhash-rs
+
 **Swift** https://github.com/lemire/SwiftWyhash
 
 **Swift**  https://github.com/lemire/SwiftWyhashBenchmark
 
 **Swift**  https://github.com/jeudesprits/SwiftWyhash
 
+**V** https://github.com/vlang/v/tree/master/vlib/hash/wyhash (v4)
+
 **Zig** https://github.com/ManDeJan/zig-wyhash
-
-**Java** https://github.com/OpenHFT/Zero-Allocation-Hashing
-
-**Rust**  https://github.com/eldruin/wyhash-rs
-
-**C#**  https://github.com/cocowalla/wyhash-dotnet
-
-**C++**  https://github.com/tommyettinger/waterhash
 
 ----------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ XXH3 was not included as it fails two tests according to SMHasher.
 
 Language Ports:
 
-**V** (v4) https://github.com/vlang/v/tree/master/vlib/hash/wyhash
+**V** https://github.com/vlang/v/tree/master/vlib/hash/wyhash (v4)
 
 **GO**  https://github.com/dgryski/go-wyhash
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ XXH3 was not included as it fails two tests according to SMHasher.
 
 Language Ports:
 
+**V** (v4) https://github.com/vlang/v/tree/master/vlib/hash/wyhash
+
 **GO**  https://github.com/dgryski/go-wyhash
 
 **GO**  https://github.com/orisano/wyhash


### PR DESCRIPTION
Hi @wangyi-fudan,

Nice work on wyhash! 🎉

I have created a port of wyhash v4 in V. You can see it here: https://github.com/vlang/v/tree/master/vlib/hash/wyhash

We are using it in our Hashmap.

This PR adds it to the list of ports. It also arranges the list alphabetically, since the order was a bit random previously. Let me know if you would like it another way .

Our port currently includes the C version as an alternative, since we are using it for performance tuning/comparisons. This will be removed soon. 