### PR TITLE
when mixing two u64, add a linear step to avoid losing entropy

### DIFF
--- a/wyhash.h
+++ b/wyhash.h
@@ -29,7 +29,7 @@ static inline uint64_t _wymum(uint64_t A, uint64_t B){
 #endif
 }
 static inline uint64_t _wymix(const uint64_t A, const uint64_t B) { return _wyrotr(A-B,43)^_wymum(A,B); }
-static inline uint64_t wyrand(uint64_t *seed){ *seed+=0xa0761d6478bd642full; return _wymix(*seed^0xe7037ed1a0b428dbull,*seed); }
+static inline uint64_t wyrand(uint64_t *seed){ *seed+=0xa0761d6478bd642full; return _wymum(*seed^0xe7037ed1a0b428dbull,*seed); }
 static inline double wy2u01(uint64_t r){ const double _wynorm=1.0/(1ull<<52); return (r>>11)*_wynorm; }
 static inline double wy2gau(uint64_t r){ const double _wynorm=1.0/(1ull<<20); return ((r&0x1fffff)+((r>>21)&0x1fffff)+((r>>42)&0x1fffff))*_wynorm-3.0; }
 #ifndef WYHASH_LITTLE_ENDIAN

--- a/wyhash.h
+++ b/wyhash.h
@@ -29,7 +29,7 @@ static inline uint64_t _wymum(uint64_t A, uint64_t B){
 #endif
 }
 static inline uint64_t _wymix(const uint64_t A, const uint64_t B) { return _wyrotr(A-B,43)^_wymum(A,B); }
-static inline uint64_t wyrand(uint64_t *seed){ *seed+=0xa0761d6478bd642full; return _wymum(*seed^0xe7037ed1a0b428dbull,*seed); }
+static inline uint64_t wyrand(uint64_t *seed){ *seed+=0xa0761d6478bd642full; return _wymix(*seed^0xe7037ed1a0b428dbull,*seed); }
 static inline double wy2u01(uint64_t r){ const double _wynorm=1.0/(1ull<<52); return (r>>11)*_wynorm; }
 static inline double wy2gau(uint64_t r){ const double _wynorm=1.0/(1ull<<20); return ((r&0x1fffff)+((r>>21)&0x1fffff)+((r>>42)&0x1fffff))*_wynorm-3.0; }
 #ifndef WYHASH_LITTLE_ENDIAN

--- a/wyhash.h
+++ b/wyhash.h
@@ -9,8 +9,10 @@
 #endif
 #if defined(__GNUC__) || defined(__INTEL_COMPILER) || defined(__clang__)
 #define _likely_(x) __builtin_expect(x,1)
+#define _unlike_(x) __builtin_expect(x,0)
 #else
 #define _likely_(x) (x)
+#define _unlike_(x) (x)
 #endif
 static inline uint64_t _wyrotr(uint64_t v, unsigned k){ return (v>>k)|(v<<(64-k)); }
 static inline uint64_t _wymum(uint64_t A, uint64_t B){
@@ -26,6 +28,7 @@ static inline uint64_t _wymum(uint64_t A, uint64_t B){
  lo=t+(rm1<<32); c+=lo<t; hi=rh+(rm0>>32)+(rm1>>32)+c; return hi^lo;
 #endif
 }
+static inline uint64_t _wymix(const uint64_t A, const uint64_t B) { return _wyrotr(A-B,43)^_wymum(A,B); }
 static inline uint64_t wyrand(uint64_t *seed){ *seed+=0xa0761d6478bd642full; return _wymum(*seed^0xe7037ed1a0b428dbull,*seed); }
 static inline double wy2u01(uint64_t r){ const double _wynorm=1.0/(1ull<<52); return (r>>11)*_wynorm; }
 static inline double wy2gau(uint64_t r){ const double _wynorm=1.0/(1ull<<20); return ((r&0x1fffff)+((r>>21)&0x1fffff)+((r>>42)&0x1fffff))*_wynorm-3.0; }
@@ -56,30 +59,29 @@ static inline uint64_t FastestHash(const void *key, size_t len){
  else if(_likely_(len)) return _wymum(_wyr3(p,len),_wyr3(p,len));
  else return 0;
 }
-static inline uint64_t _wyhash(const void* key, uint64_t len, uint64_t seed, const uint64_t secret[6]){
+static inline uint64_t _wyhash(const void* key, const uint64_t len, uint64_t seed, const uint64_t secret[6]){
  const uint8_t *p=(const uint8_t*)key; uint64_t i=len; seed^=secret[4];
- if(_likely_(i<=64)){
-  label:
-  if(_likely_(i>=8)){
-   if(_likely_(i<=16)) return _wymum(_wyr8(p)^secret[0],_wyr8(p+i-8)^seed);
-   else if(_likely_(i<=32)) return _wymum(_wyr8(p)^secret[0],_wyr8(p+8)^seed)^_wymum(_wyr8(p+i-16)^secret[1],_wyr8(p+i-8)^seed);
-   else return _wymum(_wyr8(p)^secret[0],_wyr8(p+8)^seed)^_wymum(_wyr8(p+16)^secret[1],_wyr8(p+24)^seed)
-    ^_wymum(_wyr8(p+i-32)^secret[2],_wyr8(p+i-24)^seed)^_wymum(_wyr8(p+i-16)^secret[3],_wyr8(p+i-8)^seed);
-  } 
-  else {
-   if(_likely_(i>=4)) return _wymum(_wyr4(p)^secret[0],_wyr4(p+i-4)^seed);
-   else return _wymum((_likely_(i)?_wyr3(p,i):0)^secret[0],seed);
+ if(_unlike_(i>64)){
+  uint64_t see1=seed, see2=seed, see3=seed;
+  for(; _likely_(i>=64); i-=64,p+=64){
+   seed=_wymix(_wyr8(p)^secret[0],_wyr8(p+8)^seed);  see1=_wymix(_wyr8(p+16)^secret[1],_wyr8(p+24)^see1);
+   see2=_wymix(_wyr8(p+32)^secret[2],_wyr8(p+40)^see2); see3=_wymix(_wyr8(p+48)^secret[3],_wyr8(p+56)^see3);
   }
+  seed^=see1^see2^see3;
  }
- uint64_t see1=seed, see2=seed, see3=seed;
- for(; i>=64; i-=64,p+=64){
-  seed=_wymum(_wyr8(p)^secret[0],_wyr8(p+8)^seed);  see1=_wymum(_wyr8(p+16)^secret[1],_wyr8(p+24)^see1);
-  see2=_wymum(_wyr8(p+32)^secret[2],_wyr8(p+40)^see2); see3=_wymum(_wyr8(p+48)^secret[3],_wyr8(p+56)^see3);
+ if(_likely_(i>=8)){
+  if(_likely_(i<=16)) return _wymix(_wyr8(p)^secret[0],_wyr8(p+i-8)^seed);
+  else if(_likely_(i<=32)) return _wymix(_wyr8(p)^secret[0],_wyr8(p+8)^seed)^_wymix(_wyr8(p+i-16)^secret[1],_wyr8(p+i-8)^seed);
+  else return _wymix(_wyr8(p)^secret[0],_wyr8(p+8)^seed)^_wymix(_wyr8(p+16)^secret[1],_wyr8(p+24)^seed)
+   ^_wymix(_wyr8(p+i-32)^secret[2],_wyr8(p+i-24)^seed)^_wymix(_wyr8(p+i-16)^secret[3],_wyr8(p+i-8)^seed);
  }
- seed^=see1^see2^see3;
- goto label;
+ else {
+  if(_likely_(i>=4)) return _wymix(_wyr4(p)^secret[0],_wyr4(p+i-4)^seed);
+  else if (_likely_(i)) return _wymix(_wyr3(p,i)^secret[0],seed);
+  else return seed;
+ }
 }
-static inline uint64_t wyhash(const void* key, uint64_t len, uint64_t seed, const uint64_t secret[6]){ return _wymum(_wyhash(key,len,seed,secret),len^secret[5]); }
+static inline uint64_t wyhash(const void* key, uint64_t len, uint64_t seed, const uint64_t secret[6]){ return _wymum(_wyhash(key,len,seed,secret), (len^secret[5])|(uint32_t)0x80000000u); }
 static inline void make_secret(uint64_t seed, uint64_t secret[6]){
  uint8_t c[]= {15,23,27,29,30,39,43,45,46,51,53,54,57,58,60,71,75,77,78,83,85,86,89,90,92,99,101,102,105,106,108,113,114,116,120,135,139,141,142,147,149,150,153,154,156,163,165,166,169,170,172,177,178,180,184,195,197,198,201,202,204,209,210,212,216,225,226,228,232,240};
  for(size_t i=0; i<6; i++){

--- a/wyhash.h
+++ b/wyhash.h
@@ -60,9 +60,9 @@ static inline uint64_t FastestHash(const void *key, size_t len){
  else return 0;
 }
 static inline uint64_t _wyhash(const void* key, const uint64_t len, uint64_t seed, const uint64_t secret[6]){
- const uint8_t *p=(const uint8_t*)key; uint64_t i=len; seed^=secret[4];
+ const uint8_t *p=(const uint8_t*)key; uint64_t i=len; seed^=secret[4]; int loop=0;
  if(_unlike_(i>64)){
-  uint64_t see1=seed, see2=seed, see3=seed;
+  uint64_t see1=seed, see2=seed, see3=seed; loop=1;
   for(; _likely_(i>=64); i-=64,p+=64){
    seed=_wymix(_wyr8(p)^secret[0],_wyr8(p+8)^seed);  see1=_wymix(_wyr8(p+16)^secret[1],_wyr8(p+24)^see1);
    see2=_wymix(_wyr8(p+32)^secret[2],_wyr8(p+40)^see2); see3=_wymix(_wyr8(p+48)^secret[3],_wyr8(p+56)^see3);
@@ -78,7 +78,8 @@ static inline uint64_t _wyhash(const void* key, const uint64_t len, uint64_t see
  else {
   if(_likely_(i>=4)) return _wymix(_wyr4(p)^secret[0],_wyr4(p+i-4)^seed);
   else if (_likely_(i)) return _wymix(_wyr3(p,i)^secret[0],seed);
-  else return seed;
+  else if (_likely_(loop)) return seed;
+  else return _wymix(secret[0],seed);
  }
 }
 static inline uint64_t wyhash(const void* key, uint64_t len, uint64_t seed, const uint64_t secret[6]){ return _wymum(_wyhash(key,len,seed,secret), (len^secret[5])|(uint32_t)0x80000000u); }


### PR DESCRIPTION
1. another simple mixing function: `mix(a,b) = rotr(a-b,43) ^ mum(a,b)`
2. cost is very little, about additional 1~2 cycles / hash on my environment
3. to avoid `len ^ prime` gets zero, use `(len^prime) | 0x80000000` that will never be zero, and just lose 1 bit when `len >= 2G`
4. pass in rurban/smhasher tests with the secrets coming from `make_secret(102, wyhash_secret)`, the corresponding `WYHASH_VERIF` is `0x7185963C`. The testing results vary on different secret seeds. About ten seeds from `0~256` fail some tests, and `0` fail the Sparse test. It could be better to add more criteria to `make_secret` function, and lock down secrets in the release version.
5. pass demerphq/smhasher tests with the same secrets, the corresponding verification key is `0x277F2F31`.

Building on a 24 core Intel CPU and gcc 9.2, my local benchmark result looks like:

```
HashFunction	Words	512Btye	Bulk1K	Bulk64K	Bulk16M
FastestHash	265.41	60.13	120.54	7710.89	1321528.40
wyhash		175.66	9.58	10.09	10.65	8.81
xxHash64	58.34	7.68	8.70	10.20	8.99
XXH3_scalar	137.62	9.71	11.16	14.43	12.64
t1ha2_atonce	86.64	8.03	8.83	9.75	8.65
```

For `mix(a,b)`, the linear part has no complex bit permutations or mix operations, but it would keep the whole info from  `a` or `b` if another one is zero, then the left one will be taken into full mix operations on the next loop round or tailing round.