### PR TITLE
Double the speed of make_secret, fix major portability issue

### DIFF
--- a/wyhash.h
+++ b/wyhash.h
@@ -98,14 +98,21 @@ static inline void make_secret(uint64_t seed, uint64_t secret[2]) {
     do {
       ok = 1; secret[i] = 0;
       for (size_t j = 0; j < 64; j += 8) secret[i] |= ((uint64_t)c[wyrand(&seed) % sizeof(c)]) << j;
+      if (secret[i] % 2 == 0) { ok = 0; continue; }
       for (size_t j = 0; j < i; j++)
 #if defined(__GNUC__) || defined(__INTEL_COMPILER) || defined(__clang__)
-        if (__builtin_popcountll(secret[i] ^ secret[j]) != 32) ok = 0;
+        if (__builtin_popcountll(secret[i] ^ secret[j]) != 32) {
+          ok = 0;
+          break;
+        }
 #elif defined(_MSC_VER)
-        if (_mm_popcnt_u64(secret[i] ^ secret[j]) != 32) ok = 0;
+        if (_mm_popcnt_u64(secret[i] ^ secret[j]) != 32) {
+          ok = 0;
+          break;
+        }
 #endif
       if (!ok) continue;
-      for (size_t j = 2; j < 0x100000000ull; j++) if (secret[i] % j == 0) { ok = 0; break;}
+      for (uint64_t j = 3; j < 0x100000000ull; j += 2) if (secret[i] % j == 0) { ok = 0; break;}
     } while (!ok);
   }
 }

--- a/wyhash_v5.h
+++ b/wyhash_v5.h
@@ -179,14 +179,24 @@ static inline void make_secret(uint64_t seed, uint64_t secret[6]) {
             secret[i] = 0;
             for (size_t j = 0; j < 64; j += 8)
                 secret[i] |= ((uint64_t)c[wyrand(&seed) % sizeof(c)]) << j;
+            if (secret[i] % 2 == 0) {
+                ok = 0;
+                continue;
+            }
             for (size_t j = 0; j < i; j++)
 #if defined(__GNUC__) || defined(__INTEL_COMPILER) || defined(__clang__)
-                if (__builtin_popcountll(secret[i] ^ secret[j]) != 32) ok = 0;
+                if (__builtin_popcountll(secret[i] ^ secret[j]) != 32) {
+                    ok = 0;
+                    break;
+                }
 #elif defined(_MSC_VER)
-                if (_mm_popcnt_u64(secret[i] ^ secret[j]) != 32) ok = 0;
+                if (_mm_popcnt_u64(secret[i] ^ secret[j]) != 32) {
+                    ok = 0;
+                    break;
+                }
 #endif
             if (!ok) continue;
-            for (size_t j = 2; j < 0x100000000ull; j++)
+            for (uint64_t j = 3; j < 0x100000000ull; j += 2)
                 if (secret[i] % j == 0) {
                     ok = 0;
                     break;

--- a/wyhash_v6.h
+++ b/wyhash_v6.h
@@ -275,14 +275,24 @@ static inline void make_secret(uint64_t seed, uint64_t secret[10]) {
             secret[i] = 0;
             for (size_t j = 0; j < 64; j += 8)
                 secret[i] |= ((uint64_t)c[wyrand(&seed) % sizeof(c)]) << j;
+            if (secret[i] % 2 == 0) {
+                ok = 0;
+                continue;
+            }
             for (size_t j = 0; j < i; j++)
 #if defined(__GNUC__) || defined(__INTEL_COMPILER) || defined(__clang__)
-                if (__builtin_popcountll(secret[i] ^ secret[j]) != 32) ok = 0;
+                if (__builtin_popcountll(secret[i] ^ secret[j]) != 32) {
+                    ok = 0;
+                    break;
+                }
 #elif defined(_MSC_VER)
-                if (_mm_popcnt_u64(secret[i] ^ secret[j]) != 32) ok = 0;
+                if (_mm_popcnt_u64(secret[i] ^ secret[j]) != 32) {
+                    ok = 0;
+                    break;
+                }
 #endif
             if (!ok) continue;
-            for (size_t j = 2; j < 0x100000000ull; j++)
+            for (uint64_t j = 3; j < 0x100000000ull; j += 2)
                 if (secret[i] % j == 0) {
                     ok = 0;
                     break;

--- a/wyhash_v6.h
+++ b/wyhash_v6.h
@@ -6,7 +6,7 @@
 #if defined(_MSC_VER) && defined(_M_X64)
 #    include <intrin.h>
 #    pragma intrinsic(_umul128)
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) && defined(__SSE2__)
 #    include <x86intrin.h>
 #endif
 #if defined(__GNUC__) || defined(__INTEL_COMPILER) || defined(__clang__)


### PR DESCRIPTION
1. Add some early exits for platforms with slow popcounts
2. Don't repeatedly modulo against even numbers, that is pointless
3. Check for `__SSE2__` before including `x86intrin.h`.