### PR TITLE
More portable wyhash.h

### DIFF
--- a/wyhash.h
+++ b/wyhash.h
@@ -27,7 +27,7 @@
 static inline uint64_t _wyrot(uint64_t x) { return (x>>32)|(x<<32); }
 static inline void _wymum(uint64_t *A, uint64_t *B){
 #if(WYHASH_32BIT_MUM)
-  uint64_t hh=(*A>>32)*(*B>>32), hl=(*A>>32)*(unsigned)*B, lh=(unsigned)*A*(*B>>32), ll=(uint64_t)(unsigned)*A*(unsigned)*B;
+  uint64_t hh=(*A>>32)*(*B>>32), hl=(*A>>32)*(uint32_t)*B, lh=(uint32_t)*A*(*B>>32), ll=(uint64_t)(uint32_t)*A*(uint32_t)*B;
   #if(WYHASH_CONDOM>1)
   *A^=_wyrot(hl)^hh; *B^=_wyrot(lh)^ll;
   #else
@@ -73,13 +73,13 @@ static inline uint64_t _wymix(uint64_t A, uint64_t B){ _wymum(&A,&B); return A^B
 #endif
 #if (WYHASH_LITTLE_ENDIAN)
 static inline uint64_t _wyr8(const uint8_t *p) { uint64_t v; memcpy(&v, p, 8); return v;}
-static inline uint64_t _wyr4(const uint8_t *p) { unsigned v; memcpy(&v, p, 4); return v;}
+static inline uint64_t _wyr4(const uint8_t *p) { uint32_t v; memcpy(&v, p, 4); return v;}
 #elif defined(__GNUC__) || defined(__INTEL_COMPILER) || defined(__clang__)
 static inline uint64_t _wyr8(const uint8_t *p) { uint64_t v; memcpy(&v, p, 8); return __builtin_bswap64(v);}
-static inline uint64_t _wyr4(const uint8_t *p) { unsigned v; memcpy(&v, p, 4); return __builtin_bswap32(v);}
+static inline uint64_t _wyr4(const uint8_t *p) { uint32_t v; memcpy(&v, p, 4); return __builtin_bswap32(v);}
 #elif defined(_MSC_VER)
 static inline uint64_t _wyr8(const uint8_t *p) { uint64_t v; memcpy(&v, p, 8); return _byteswap_uint64(v);}
-static inline uint64_t _wyr4(const uint8_t *p) { unsigned v; memcpy(&v, p, 4); return _byteswap_ulong(v);}
+static inline uint64_t _wyr4(const uint8_t *p) { uint32_t v; memcpy(&v, p, 4); return _byteswap_ulong(v);}
 #else
 static inline uint64_t _wyr8(const uint8_t *p) {
   uint64_t v;
@@ -96,7 +96,7 @@ static inline uint64_t _wyr8(const uint8_t *p) {
   );
 }
 static inline uint64_t _wyr4(const uint8_t *p) {
-  unsigned v;
+  uint32_t v;
   memcpy(&v, p, 4);
   return (
       ((v >> 24) & 0xff)


### PR DESCRIPTION
As there are some catch-all `#else`-cases missing in the pre-processor conditions, some functions can end up undefined with some compilers.
Also `unsigned` doesn't have a guaranteed size, but as far as I can tell wyhash requires many of the used `unsigned`s to be 32 bit.

To address this, this pr changes most instances of `unsigned` to `uint32_t` *(I'm not sure about the `unsigned` passed to `_wyr3` as a second parameter, so I left it as is for now)* and adds fallback code for Hamming Weight(popcount) as well as BigEndian `_wyr4` and `_wyr8`.

The popcount fallback used is a well-known to be efficient textbook implementation, that can also be found eg on [Wikipedia](https://en.wikipedia.org/wiki/Hamming_weight).
For comparison, I've benched it on 3GiB of random data on my x86_64 CPU, here's [the bench code attached](https://github.com/wangyi-fudan/wyhash/files/6072413/hamming_bench.c.txt).
With `gcc -O3 -march=native`:
```
(sys) ADD popcount:     706.37
(sys) MUL popcount:     520.89   <-- this pr's fallback
(sys) builtin popcount: 197.60
```

While slower, this will only be used if no builtin is available anyway.

Interestingly, without `march=native`, the fallback code is a tad faster than the builtin.
`gcc -O3`:
```
(sys) ADD popcount:     879.83
(sys) MUL popcount:     545.83   <-- this pr's fallback
(sys) builtin popcount: 679.09
```