### PR TITLE
Allow usage of wyhash32.h after wyhash.h, add known bad seeds

### DIFF
--- a/wyhash32.h
+++ b/wyhash32.h
@@ -14,6 +14,8 @@ static inline void _wymix32(unsigned  *A,  unsigned  *B){
   *A=(unsigned)c;
   *B=(unsigned)(c>>32);
 }
+// This version is vulnerable when used with a few bad seeds, which should be skipped beforehand:
+// 0x429dacdd, 0xd637dbf3
 static inline unsigned wyhash32(const void *key, uint64_t len, unsigned seed) {
   const uint8_t *p=(const uint8_t *)key; uint64_t i=len;
   unsigned see1=(unsigned)len; seed^=(unsigned)(len>>32); _wymix32(&seed, &see1);
@@ -21,12 +23,15 @@ static inline unsigned wyhash32(const void *key, uint64_t len, unsigned seed) {
   if(i>=4){ seed^=_wyr32(p); see1^=_wyr32(p+i-4); } else if (i) seed^=_wyr24(p,(unsigned)i);
   _wymix32(&seed, &see1); _wymix32(&seed, &see1); return seed^see1;
 }
+// duplicate definition in wyhash.h also
+#ifndef wyhash_final_version_3
 static inline uint64_t wyrand(uint64_t *seed){  
   *seed+=0xa0761d6478bd642full; 
   uint64_t  see1=*seed^0xe7037ed1a0b428dbull;
   see1*=(see1>>32)|(see1<<32);
   return  (*seed*((*seed>>32)|(*seed<<32)))^((see1>>32)|(see1<<32));
 }
+#endif
 static inline unsigned wy32x32(unsigned a,  unsigned  b) { _wymix32(&a,&b); _wymix32(&a,&b); return a^b;  }
 static inline float wy2u01(unsigned r) { const float _wynorm=1.0f/(1ull<<23); return (r>>9)*_wynorm;}
 static inline float wy2gau(unsigned r) { const float _wynorm=1.0f/(1ull<<9); return ((r&0x3ff)+((r>>10)&0x3ff)+((r>>20)&0x3ff))*_wynorm-3.0f;}


### PR DESCRIPTION
Previous versions allowed both headers together (even if it made no sense).
With this hack smhasher can now include wyhash32.h after wyhash.h on 32bit.

Also add the list of known bad seeds of the 32bit and 64bit variants.
Those should be skipped or changed at initialisation to avoid setting WYHASH_CONDOM to 2.
Some seeds just create the hash 0 with some known keys, some create collisions
with more keys. MUM-hashes are very sensible to bad seeds, but not much to worry
about.