### PR TITLE
docs: Fix a few typos

### DIFF
--- a/old_versions/wyhash_final2.h
+++ b/old_versions/wyhash_final2.h
@@ -210,7 +210,7 @@ static inline void make_secret(uint64_t seed, uint64_t *secret){
     For 1 billion keys,   Prob(Colision)=2^-5,  worry but not die
     For more keys, define wyhashmap128 and use double hash functions to construct 128 bit keys which is very safe
     example code:
-    const  uint64_t  size=1ull<<20;	//	we use fixed memory unlike auto increasing ones. it thus maximize memoery usage. A power-2 size will be fastest
+    const  uint64_t  size=1ull<<20;	//	we use fixed memory unlike auto increasing ones. it thus maximize memory usage. A power-2 size will be fastest
     wyhashmap_t  *idx=(wyhashmap_t*)calloc(size,sizeof(wyhashmap_t));	//	allocate the index and set it to zero.
     vector<value_class>	value(size);	//	we only care about the index, user should maintain his own value vectors.
     vector<string>	keys(size);	//	also you can maintain your own real keys

--- a/old_versions/wyhash_v4.h
+++ b/old_versions/wyhash_v4.h
@@ -187,7 +187,7 @@ values(1ull<<20); string	s;	size_t	pos=0; for(cin>>s;	!cin.eof();	cin>>s){
     }
     return	pos;
 }*/
-//  the minimum bloom filter. paramters calculator: https://hur.st/bloomfilter/
+//  the minimum bloom filter. parameters calculator: https://hur.st/bloomfilter/
 static inline void bfpush(uint64_t hash_of_key, std::vector<bool> &bitset,
                           size_t size, size_t round) {
     for (size_t i = 0; i < round; i++)

--- a/wyhash.h
+++ b/wyhash.h
@@ -193,7 +193,7 @@ static inline void make_secret(uint64_t seed, uint64_t *secret){
     First we use pos=hash1(key) to approximately locate the bucket.
     Then we search signature=hash2(key) from pos linearly.
     If we find a bucket with matched signature we report the bucket
-    Or if we meet a bucket whose signifure=0, we report a new position to insert
+    Or if we meet a bucket whose signature=0, we report a new position to insert
     The signature collision probability is very low as we usually searched N~10 buckets.
     By combining hash1 and hash2, we acturally have 128 bit anti-collision strength.
     hash1 and hash2 can be the same function, resulting lower collision resistance but faster.


### PR DESCRIPTION
There are small typos in:
- old_versions/wyhash_final2.h
- old_versions/wyhash_v4.h
- wyhash.h

Fixes:
- Should read `signature` rather than `signifure`.
- Should read `parameters` rather than `paramters`.
- Should read `memory` rather than `memoery`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md