### PR TITLE
makefile: added -std++11 to CXXFLAGS

### DIFF
--- a/benchmark.cpp
+++ b/benchmark.cpp
@@ -1,67 +1,106 @@
-#include	<sys/time.h>
-#include	<iostream>
-#include	<fstream>
-#include	<cstdlib>
-#include	<stdint.h>
-#include	<cstring>
-#include	<vector>
-#ifndef	XXH3
-#include	"wyhash.h"
+#include <sys/time.h>
+#include <iostream>
+#include <fstream>
+#include <cstdlib>
+#include <stdint.h>
+#include <string>
+#include <cstring>
+#include <vector>
+#ifndef XXH3
+#include "wyhash.h"
 #else
-#include	"../xxHash/xxh3.h"
+#include "../xxHash/xxh3.h"
 #endif
-using	namespace	std;
-struct	ha{	
-  size_t	operator()(const	string	&s,	uint64_t seed)const{
-    #ifndef	XXH3
-    return  wyhash(s.c_str(),s.size(),seed,_wyp);	
-    #else
-    return  XXH3_64bits_withSeed(s.c_str(),s.size(),seed);	
-    #endif
-  }
+
+using namespace std;
+
+struct ha
+{
+    size_t operator()(const string &s, uint64_t seed)const
+    {
+        #ifndef XXH3
+        return wyhash(s.c_str(),s.size(),seed,_wyp);
+        #else
+        return XXH3_64bits_withSeed(s.c_str(),s.size(),seed);
+        #endif
+    }
 };
 
-vector<string>	v;	
+vector <string> v;
 template <class Hasher>
-uint64_t	bench_hash(const	char	*name){
-	Hasher	h;	string	s;	timeval	beg,	end;	
-	uint64_t	dummy=0;	const	uint64_t	N=v.size(),	R=0x1000;
-	cerr.precision(2);	cerr.setf(ios::fixed);	cerr<<'|'<<name<<(strlen(name)<8?"\t\t|":"\t|");
-	
-	gettimeofday(&beg,NULL);
-	for(size_t  r=0;    r<R;    r++)	for(size_t	i=0;	i<N;	i++)	dummy+=h(v[i],r);
-	gettimeofday(&end,NULL);
-	cerr<<1e-6*R*N/(end.tv_sec-beg.tv_sec+1e-6*(end.tv_usec-beg.tv_usec))<<"\t\t|";
+uint64_t bench_hash(const char *name)
+{
+    Hasher h;
+    string s;
+    timeval beg, end;
+    uint64_t dummy=0;
+    const uint64_t N=v.size(), R=0x1000;
 
-	s.resize(1<<8);
-	gettimeofday(&beg,NULL);
-	for(size_t  r=0;    r<(R<<14);    r++)	dummy+=h(s,r);
-	gettimeofday(&end,NULL);
-	cerr<<1e-9*(R<<14)*s.size()/(end.tv_sec-beg.tv_sec+1e-6*(end.tv_usec-beg.tv_usec))<<"\t\t|";
+    cerr.precision(2);
+    cerr.setf(ios::fixed);
+    cerr<<'|'<<name<<(strlen(name)<8?"\t\t|":"\t|");
 
-	s.resize(1<<16);
-	gettimeofday(&beg,NULL);
-	for(size_t  r=0;    r<(R<<6);    r++)	dummy+=h(s,r);
-	gettimeofday(&end,NULL);
-	cerr<<1e-9*(R<<6)*s.size()/(end.tv_sec-beg.tv_sec+1e-6*(end.tv_usec-beg.tv_usec))<<"\t\t|\n";
-	return	dummy;
+    gettimeofday(&beg,NULL);
+    for(size_t r=0; r<R; r++)
+        for(size_t i=0; i<N; i++)
+            dummy+=h(v[i],r);
+    gettimeofday(&end,NULL);
+    cerr<<1e-6*R*N/(end.tv_sec-beg.tv_sec+1e-6*(end.tv_usec-beg.tv_usec))<<"\t\t|";
+
+    s.resize(1<<8);
+    gettimeofday(&beg,NULL);
+    for(size_t r=0; r<(R<<14); r++)
+        dummy+=h(s,r);
+    gettimeofday(&end,NULL);
+    cerr<<1e-9*(R<<14)*s.size()/(end.tv_sec-beg.tv_sec+1e-6*(end.tv_usec-beg.tv_usec))<<"\t\t|";
+
+    s.resize(1<<16);
+    gettimeofday(&beg,NULL);
+    for(size_t r=0; r<(R<<6); r++)
+        dummy+=h(s,r);
+    gettimeofday(&end,NULL);
+    cerr<<1e-9*(R<<6)*s.size()/(end.tv_sec-beg.tv_sec+1e-6*(end.tv_usec-beg.tv_usec))<<"\t\t|\n";
+    return dummy;
 }
 
-int	main(void){
-	string	file="/usr/share/dict/words", s;
-	ifstream	fi(file.c_str());
-	for(fi>>s;	!fi.eof();	fi>>s)	if(s.size())	v.push_back(s);
-	fi.close();
-	//shuffle the array to benchmark random access
-	for(size_t	i=v.size()-1;	i;	i--)	swap(v[i],v[rand()%(i+1)]);
-	uint64_t	r=0;
-	cerr<<file<<'\n';
-	cerr<<"|hash function\t|short hash/us\t|bulk_256B GB/s\t|bulk_64KB GB/s\t|\n";
-	cerr<<"|----\t\t|----\t\t|----\t\t|----\t\t|\n";
-    #ifndef	XXH3
-	r+=bench_hash<ha>("wyhash");
+int main(int argc, char **argv)
+{
+    string file_name="/usr/share/dict/words", help_s="-h", s;
+    if(argc>1)
+    {
+        if(help_s.compare(argv[1])==0)
+        {
+            cout<<"usage:\n"<<argv[0]<<" <file>\n";
+            cout<<"if no arguments given \'"<<file_name<<"\' is used\n";
+            return 0;
+        }
+        file_name=argv[1];
+    }
+    ifstream fi(file_name.c_str());
+    if(fi.fail())
+    {
+        cout<<"File \'"<<file_name<<"\' not found.\n";
+        cout<<"Try `-h\' for help.\n";
+        return 1;
+    }
+    for(fi>>s; !fi.eof(); fi>>s)
+        if(s.size())
+            v.push_back(s);
+    fi.close();
+    //shuffle the array to benchmark random access
+    for(size_t i=v.size()-1; i; i--)
+        swap(v[i],v[rand()%(i+1)]);
+
+    uint64_t r=0;
+    cerr<<file_name<<'\n';
+    cerr<<"|hash function\t|short hash/us\t|bulk_256B GB/s\t|bulk_64KB GB/s\t|\n";
+    cerr<<"|----\t\t|----\t\t|----\t\t|----\t\t|\n";
+
+    #ifndef XXH3
+    r+=bench_hash<ha>("wyhash");
     #else
-	r+=bench_hash<ha>("xxh3");
+    r+=bench_hash<ha>("xxh3");
     #endif
-	return	r;
+
+    return r;
 }

--- a/makefile
+++ b/makefile
@@ -1,19 +1,33 @@
-CXX=g++
-all:	test_vector wyhash0 wyhash1 wyhash2 xxh3scalar xxh3sse2 xxh3avx2
-test_vector:	test_vector.cpp wyhash.h makefile
-	$(CXX) test_vector.cpp -o test_vector -O3 -s  -Wall -march=native
-wyhash0:	benchmark.cpp wyhash.h makefile
-	$(CXX) benchmark.cpp -o wyhash0 -O3 -s  -Wall -march=native -DWYHASH_CONDOM=0
-wyhash1:	benchmark.cpp wyhash.h makefile
-	$(CXX) benchmark.cpp -o wyhash1 -O3 -s  -Wall -march=native -DWYHASH_CONDOM=1
-wyhash2:	benchmark.cpp wyhash.h makefile
-	$(CXX) benchmark.cpp -o wyhash2 -O3 -s  -Wall -march=native -DWYHASH_CONDOM=2
-xxh3scalar:	benchmark.cpp makefile
-	$(CXX) benchmark.cpp -o xxh3scalar -O3 -s  -Wall -march=native -DXXH_VECTOR=0 -DXXH3
-xxh3sse2:	benchmark.cpp makefile
-	$(CXX) benchmark.cpp -o xxh3sse2 -O3 -s  -Wall -march=native -DXXH_VECTOR=1 -DXXH3
-xxh3avx2:	benchmark.cpp makefile
-	$(CXX) benchmark.cpp -o xxh3avx2 -O3 -s  -Wall -march=native -DXXH_VECTOR=2 -DXXH3
+# wyhash bench makefile
+
+CXX = g++
+CXXFLAGS = -std=c++11 -O2 -s -Wall -march=native
+
+TARGETS = test_vector wyhash0 wyhash1 wyhash2 xxh3scalar xxh3sse2 xxh3avx2
+
+all:	$(TARGETS)
+
+test_vector:	test_vector.cpp wyhash.h
+	$(CXX) test_vector.cpp -o test_vector $(CXXFLAGS)
+
+wyhash0:	benchmark.cpp wyhash.h
+	$(CXX) benchmark.cpp -o wyhash0 $(CXXFLAGS) -DWYHASH_CONDOM=0
+
+wyhash1:	benchmark.cpp wyhash.h
+	$(CXX) benchmark.cpp -o wyhash1 $(CXXFLAGS) -DWYHASH_CONDOM=1
+
+wyhash2:	benchmark.cpp wyhash.h
+	$(CXX) benchmark.cpp -o wyhash2 $(CXXFLAGS) -DWYHASH_CONDOM=2
+
+xxh3scalar:	benchmark.cpp
+	$(CXX) benchmark.cpp -o xxh3scalar $(CXXFLAGS) -DXXH_VECTOR=0 -DXXH3
+
+xxh3sse2:	benchmark.cpp
+	$(CXX) benchmark.cpp -o xxh3sse2 $(CXXFLAGS) -DXXH_VECTOR=1 -DXXH3
+
+xxh3avx2:	benchmark.cpp
+	$(CXX) benchmark.cpp -o xxh3avx2 $(CXXFLAGS) -DXXH_VECTOR=2 -DXXH3
+
 clean:
-	rm test_vector wyhash0 wyhash1 wyhash2 xxh3scalar xxh3sse2 xxh3avx2
+	rm $(TARGETS)
 

--- a/test_vector.cpp
+++ b/test_vector.cpp
@@ -1,10 +1,11 @@
+#include <stdint.h>
 #include <iostream>
 #include <vector>
 #include "wyhash.h"
 using namespace std;
 
 int main(void) {
-    vector<string> v = {
+    vector<string> msgs_v = {
         "",
         "a",
         "abc",
@@ -12,10 +13,24 @@ int main(void) {
         "abcdefghijklmnopqrstuvwxyz",
         "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789",
         "1234567890123456789012345678901234567890123456789012345678901234567890"
-        "1234567890"};
-    for (size_t i = 0; i < v.size(); i++) {
-        cout << "wyhash(\"" << v[i] << "\"," << i << ")=" << hex
-             << wyhash(v[i].c_str(), v[i].size(), i, _wyp) << '\n';
+        "1234567890"
+    };
+    vector<uint64_t> etalons_v = {
+        0x42bc986dc5eec4d3,
+        0x84508dc903c31551,
+        0x0bc54887cfc9ecb1,
+        0x6e2ff3298208a67c,
+        0x9a64e42e897195b9,
+        0x9199383239c32554,
+        0x7c1ccf6bba30f5a5
+    };
+    uint64_t hash;
+    for (size_t i = 0; i < msgs_v.size(); i++) {
+        hash = wyhash(msgs_v[i].c_str(), msgs_v[i].size(), i, _wyp);
+        cout << "wyhash(\"" << msgs_v[i] << "\"," << i << ")=" << hex
+             << hash << hex << "\n";
+        hash == etalons_v[i] ? true : cout << "\tNOK! Expected: "
+             << hex << etalons_v[i] << "\n";
     }
     return 0;
 }


### PR DESCRIPTION
Added few changes:

makefile: added -std=c++11 to CXXFLAGS
as gcc complains:
error: in C++98 ‘v’ must be initialized by constructor, not by ‘{...}’
Also simplified it, by using variables instead of sheer file names,full flags, and so on.

test_vector.cpp: added standard reference, etalon, hash values and compare with hashing results to check if they are correct.

benchmark.cpp: added check whether file {/usr/share/dict/words} is even opened. Without it benchmark just hangs if the file is not present.
Also added file as argument so other file can be used, and simple help with `-h'.
