### PR TITLE
Imporoved _wyr32 portability

### DIFF
--- a/wyhash32.h
+++ b/wyhash32.h
@@ -1,13 +1,8 @@
 // Author: Wang Yi <godspeed_china@yeah.net>
 #include <stdint.h>
 #include <string.h>
-#ifndef WYHASH32_BIG_ENDIAN
-static inline unsigned _wyr32(const uint8_t *p) { unsigned v; memcpy(&v, p, 4); return v;}
-#elif defined(__GNUC__) || defined(__INTEL_COMPILER) || defined(__clang__)
-static inline unsigned _wyr32(const uint8_t *p) { unsigned v; memcpy(&v, p, 4); return __builtin_bswap32(v);}
-#elif defined(_MSC_VER)
-static inline unsigned _wyr32(const uint8_t *p) { unsigned v; memcpy(&v, p, 4); return _byteswap_ulong(v);}
-#endif
+
+static inline unsigned _wyr32(const uint8_t *p) { return (uint32_t)(255&p[3])<<0|(uint32_t)(255&p[2])<<010|(uint32_t)(255&p[1])<<020|(uint32_t)(255&p[0])<<030;}
 static inline unsigned _wyr24(const uint8_t *p, unsigned k) { return (((unsigned)p[0])<<16)|(((unsigned)p[k>>1])<<8)|p[k-1];}
 static inline void _wymix32(unsigned  *A,  unsigned  *B){
   uint64_t  c=*A^0x53c5ca59u;  c*=*B^0x74743c1bu;


### PR DESCRIPTION
Use a single function for _wyr32 that doesn't rely on  compilers specific built macros. Assembly generated with the -0s option is the same. Check it [here](https://godbolt.org/z/vnc4crdac).