### PR TITLE
test vector simplified, and made it look like md5sum

### DIFF
--- a/test_vector.cpp
+++ b/test_vector.cpp
@@ -16,19 +16,11 @@ int main(void) {
         "1234567890123456789012345678901234567890123456789012345678901234567890"
         "1234567890"
     };
-    vector<uint64_t> etalons_v = {
-        0x42bc986dc5eec4d3,
-        0x84508dc903c31551,
-        0x0bc54887cfc9ecb1,
-        0x6e2ff3298208a67c,
-        0x9a64e42e897195b9,
-        0x9199383239c32554,
-        0x7c1ccf6bba30f5a5
-    };
     uint64_t hash;
+    cout << "# wyhash         message,  seed" << "\n";
     for (size_t i = 0; i < msgs_v.size(); i++) {
         hash = wyhash(msgs_v[i].c_str(), msgs_v[i].size(), i, _wyp);
-        cout << "wyhash(\"" << msgs_v[i] << "\"," << i << ")=" << hex  << hash << hex << "\n";
+        cout << hex << hash << " \"" << msgs_v[i] << "\",  " << i << "\n";
     }
     return 0;
 }


### PR DESCRIPTION
It was unclear where these hashes are so made it behave more like md5sum/sha1sum/...
Hash '\#' at the begining is compatible with BSD style of commenting syms where they put hash name.

```
# wyhash         message,  seed
93228a4de0eec5a2 "",  0
c5bac3db178713c4 "a",  1
a97f2f7b1d9b3314 "abc",  2
786d1f1df3801df4 "message digest",  3
```

Also removed etalons as they seem to be unupdated and, therefore useless.
